### PR TITLE
fix: display user name or uuid in message lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2867,6 +2867,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -6419,6 +6420,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7813,7 +7815,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8676,7 +8679,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -10895,6 +10899,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -11007,6 +11014,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -12633,10 +12643,14 @@
       "integrity": "sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==",
       "dependencies": {
         "@peculiar/webcrypto": "^1.0.22",
+        "@unimodules/core": "*",
+        "@unimodules/react-native-adapter": "*",
         "asmcrypto.js": "^0.22.0",
         "b64-lite": "^1.3.1",
         "b64u-lite": "^1.0.1",
+        "expo-random": "*",
         "msrcrypto": "^1.5.6",
+        "react-native-securerandom": "^0.1.1",
         "str2buf": "^1.3.0",
         "webcrypto-shim": "^0.1.4"
       },
@@ -13157,6 +13171,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -14120,6 +14135,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -18806,6 +18822,7 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
+        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -22457,8 +22474,10 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -22548,6 +22567,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -23014,6 +23034,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -23549,6 +23570,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -24010,6 +24034,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/src/utils/automaticTextModeration/filterConditionForAutomatic.js
+++ b/src/utils/automaticTextModeration/filterConditionForAutomatic.js
@@ -149,11 +149,12 @@ function automaticMaskMessageAndReroute({
 
       console.log("received text moderation request: ", message);
       const originalMessage = message.text;
+      const senderUuid = request.params.uuid;
 
       ${selectedDetectionTool}
       if(checkThresholdForThirdParty){
              const moderatedMessage = originalMessage.replace(/[a-z-A-Z-!]/g, '${automaticDetectionCharacterToMaskWith}');
-             let payload = {"type":"text", originalMessage, moderatedMessage};
+             let payload = {"type":"text", originalMessage, moderatedMessage, senderUuid};
              if (reasons && reasons.length) {
                payload.reason = reasons.join(", ");
              }
@@ -281,12 +282,13 @@ function automaticBlockMessageAndReroute({ selectedDetectionTool, type }) {
     }
 
     const originalMessage = message.text;
+    const senderUuid = request.params.uuid;
     console.log("received text moderation request: ", message);
 
     ${selectedDetectionTool}
 
          if(checkThresholdForThirdParty){
-              let payload = {"type":"text", originalMessage: request.message.text};
+              let payload = {"type":"text", originalMessage, senderUuid};
               if (reasons && reasons.length) {
                 payload.reason = reasons.join(", ");
               }

--- a/src/utils/profanityFunction.js
+++ b/src/utils/profanityFunction.js
@@ -97,6 +97,6 @@ export default function profanityFunction(data) {
          tisaneApiKey:'${tisaneApiKey}',
          tisaneLanguage:'${tisaneLanguage}'
        },
-     }
+     };
   }`;
 }

--- a/src/utils/profanityFunctionForImage.js
+++ b/src/utils/profanityFunctionForImage.js
@@ -162,8 +162,8 @@ export default function profanityFunctionForImage(data) {
 
           // this block handles re-routing
           if (payload.file || payload.message) {
-            return pubnub
-            .publish({
+            payload.senderUuid = request.params.uuid;
+            return pubnub.publish({
               channel: "banned." + request.channels[0],
               message: payload,
             })
@@ -260,6 +260,6 @@ export default function profanityFunctionForImage(data) {
           sightengineRiskFactorThreshold: '${sightengineRiskFactorThreshold}',
           reRouteMessages: '${reRouteMessages}',
           applyToAllChannelIds: '${applyToAllChannelIds}'
-        }
+        };
     }`;
 }

--- a/src/utils/wordlist/index.js
+++ b/src/utils/wordlist/index.js
@@ -133,14 +133,15 @@ function wordListMaskWordsAndReroute({ regex, wordListCharacterToMaskWith, type 
       badWords.test(request.message.text) &&
       !bannedChannel.test(request.channels[0])
     ) {
-      var originalMessage = request.message.text
+      const originalMessage = request.message.text;
+      const senderUuid = request.params.uuid;
       const moderatedMessage = originalMessage.replace(badWords, '${wordListCharacterToMaskWith.repeat(
         3
       )}');
       request.message.text = moderatedMessage;
       pubnub.publish({
       "channel": 'banned.'+request.channels[0],
-      "message":{ "type":"text", originalMessage, moderatedMessage }
+      "message":{ "type":"text", originalMessage, moderatedMessage, senderUuid }
       }).then((publishResponse) => {
         console.log(publishResponse)
       }).catch((err) => {
@@ -215,7 +216,11 @@ function wordListBlockMessageAndReroute({ regex, type }) {
       console.log("Found word(s) from moderation list. Publishing to banned channel");
       pubnub.publish({
       "channel": 'banned.'+request.channels[0],
-      "message": { originalMessage: message.text, "type":"text" }
+      "message": { 
+        type: "text", 
+        originalMessage: message.text, 
+        senderUuid: request.params.uuid
+      }
       }).then((publishResponse) => {
         console.log(publishResponse)
       }).catch((err) => {


### PR DESCRIPTION
**Description of change**

Ensure that original sender's uuid is sent to messages sent to banned channels
Use original sender's uuid to detect metadata on messages sent to banned channel
Properly subscribe to banned channel to reflect realtime updates

**Followed guidelines**

_Please make sure to review and check all of these items before merging pull request_

- Followed SF GitHub guidelines for creating this branch.
- Reviewed the code for any compile-time errors.
- Resolved the linting issues for the code changed during development.
- Tested this code on the Local.
- Removed the console logs added during development(if any).
