### PR TITLE
specific port 3006

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "yup": "^0.32.9"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3006 react-scripts start",
     "build": "react-scripts build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",


### PR DESCRIPTION
**Description of change**
Using port 3006 so that when this runs locally with the Moderated Chat sample app, they don't use the same port (3000)

**Followed guidelines**

_Please make sure to review and check all of these items before merging pull request_

- Followed SF GitHub guidelines for creating this branch.
- Reviewed the code for any compile-time errors.
- Resolved the linting issues for the code changed during development.
- Tested this code on the Local.
- Removed the console logs added during development(if any).
